### PR TITLE
Fix localization string format specifiers for Swift String(localized:…

### DIFF
--- a/DodoTidy/Resources/de.lproj/Localizable.strings
+++ b/DodoTidy/Resources/de.lproj/Localizable.strings
@@ -17,9 +17,9 @@
 "dashboard.thermal" = "Temperatur";
 "dashboard.system" = "System";
 "dashboard.uptime" = "Betriebszeit";
-"dashboard.cores" = "%d Kerne";
+"dashboard.cores %lld" = "%lld Kerne";
 "dashboard.bluetooth" = "Bluetooth-Geräte";
-"dashboard.connected" = "%d verbunden";
+"dashboard.connected %lld" = "%lld verbunden";
 "dashboard.quickActions" = "Schnellaktionen";
 "dashboard.smartClean" = "Intelligente Bereinigung";
 "dashboard.freeUpSpace" = "Speicher freigeben";
@@ -112,7 +112,7 @@
 "optimizer.systemOptimized" = "System ist optimiert";
 "optimizer.noTasksNeeded" = "Keine Optimierungsaufgaben erforderlich";
 "optimizer.checkAgain" = "Erneut prüfen";
-"optimizer.pending" = "%d ausstehend";
+"optimizer.pending %lld" = "%lld ausstehend";
 "optimizer.completed" = "%d abgeschlossen";
 "optimizer.failed" = "%d fehlgeschlagen";
 "optimizer.retryFailed" = "Fehlgeschlagene wiederholen";

--- a/DodoTidy/Resources/en.lproj/Localizable.strings
+++ b/DodoTidy/Resources/en.lproj/Localizable.strings
@@ -17,9 +17,9 @@
 "dashboard.thermal" = "Thermal";
 "dashboard.system" = "System";
 "dashboard.uptime" = "Uptime";
-"dashboard.cores" = "%d cores";
+"dashboard.cores %lld" = "%lld cores";
 "dashboard.bluetooth" = "Bluetooth devices";
-"dashboard.connected" = "%d connected";
+"dashboard.connected %lld" = "%lld connected";
 "dashboard.quickActions" = "Quick actions";
 "dashboard.smartClean" = "Smart clean";
 "dashboard.freeUpSpace" = "Free up space";
@@ -113,7 +113,7 @@
 "optimizer.systemOptimized" = "System is optimized";
 "optimizer.noTasksNeeded" = "No optimization tasks needed";
 "optimizer.checkAgain" = "Check again";
-"optimizer.pending" = "%d pending";
+"optimizer.pending %lld" = "%lld pending";
 "optimizer.completed" = "%d completed";
 "optimizer.failed" = "%d failed";
 "optimizer.retryFailed" = "Retry failed";

--- a/DodoTidy/Resources/fr.lproj/Localizable.strings
+++ b/DodoTidy/Resources/fr.lproj/Localizable.strings
@@ -17,9 +17,9 @@
 "dashboard.thermal" = "Thermique";
 "dashboard.system" = "Système";
 "dashboard.uptime" = "Temps de fonctionnement";
-"dashboard.cores" = "%d cœurs";
+"dashboard.cores %lld" = "%lld cœurs";
 "dashboard.bluetooth" = "Appareils Bluetooth";
-"dashboard.connected" = "%d connectés";
+"dashboard.connected %lld" = "%lld connectés";
 "dashboard.quickActions" = "Actions rapides";
 "dashboard.smartClean" = "Nettoyage intelligent";
 "dashboard.freeUpSpace" = "Libérer de l'espace";
@@ -112,7 +112,7 @@
 "optimizer.systemOptimized" = "Le système est optimisé";
 "optimizer.noTasksNeeded" = "Aucune tâche d'optimisation nécessaire";
 "optimizer.checkAgain" = "Vérifier à nouveau";
-"optimizer.pending" = "%d en attente";
+"optimizer.pending %lld" = "%lld en attente";
 "optimizer.completed" = "%d terminées";
 "optimizer.failed" = "%d échouées";
 "optimizer.retryFailed" = "Réessayer les échecs";

--- a/DodoTidy/Resources/tr.lproj/Localizable.strings
+++ b/DodoTidy/Resources/tr.lproj/Localizable.strings
@@ -17,9 +17,9 @@
 "dashboard.thermal" = "Termal";
 "dashboard.system" = "Sistem";
 "dashboard.uptime" = "Çalışma Süresi";
-"dashboard.cores" = "%d çekirdek";
+"dashboard.cores %lld" = "%lld çekirdek";
 "dashboard.bluetooth" = "Bluetooth cihazları";
-"dashboard.connected" = "%d bağlı";
+"dashboard.connected %lld" = "%lld bağlı";
 "dashboard.quickActions" = "Hızlı işlemler";
 "dashboard.smartClean" = "Akıllı temizlik";
 "dashboard.freeUpSpace" = "Alan aç";
@@ -113,7 +113,7 @@
 "optimizer.systemOptimized" = "Sistem optimize edilmiş";
 "optimizer.noTasksNeeded" = "Optimizasyon görevi gerekli değil";
 "optimizer.checkAgain" = "Tekrar kontrol et";
-"optimizer.pending" = "%d bekliyor";
+"optimizer.pending %lld" = "%lld bekliyor";
 "optimizer.completed" = "%d tamamlandı";
 "optimizer.failed" = "%d başarısız";
 "optimizer.retryFailed" = "Başarısızları yeniden dene";

--- a/DodoTidy/Views/MainWindow/OptimizerView.swift
+++ b/DodoTidy/Views/MainWindow/OptimizerView.swift
@@ -256,7 +256,7 @@ struct OptimizerView: View {
                         Circle()
                             .fill(Color.dodoInfo)
                             .frame(width: 8, height: 8)
-                        Text(String(localized: "optimizer.pending \(dodoService.optimizer.pendingTaskCount)"))
+                        Text("optimizer.pending \(dodoService.optimizer.pendingTaskCount)")
                             .font(.dodoCaption)
                             .foregroundColor(.dodoTextSecondary)
                     }


### PR DESCRIPTION
## Summary
Updated localization string keys to use `%lld` format specifier instead of `%d` for compatibility with Swift's `String(localized:)` string interpolation feature.

## Problem
When using Swift's `String(localized:)` initializer with string interpolation like:
```swift
Text(String(localized: "optimizer.pending \(pendingTaskCount)"))

